### PR TITLE
Fix for node.js > 16, bump versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It features:
 
 To run this project, you will need installed
 
-- npm (v16)
+- node.js (v16+)
 - sbt
 - a jdk 11
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scala.sys.process.Process
 
 ThisBuild / version := "1.0.0"
 
-ThisBuild / scalaVersion := "3.2.0"
+ThisBuild / scalaVersion := "3.3.1"
 
 val circeVersion = "0.14.1"
 
@@ -22,7 +22,7 @@ lazy val server = project
   .settings(
     libraryDependencies ++= List(
       // cask as server (other choices are zio-http, http4s, akka-http, play...)
-      "com.lihaoyi" %% "cask" % "0.8.3"
+      "com.lihaoyi" %% "cask" % "0.9.1"
     ),
     assembly / mainClass := Some("server.Server"),
     assembly / assemblyJarName := "app.jar"
@@ -39,9 +39,9 @@ lazy val frontend = project
   .settings(
     libraryDependencies ++= List(
       // web framework (other choices are slinky, scala-js-react, outwatch...)
-      "com.raquo" %%% "laminar" % "0.14.5",
+      "com.raquo" %%% "laminar" % "16.0.0",
       // web component library (other (non-exclusive) choices are material-ui, bootstrap...)
-      "be.doeraene" %%% "web-components-ui5" % "1.8.0"
+      "be.doeraene" %%% "web-components-ui5" % "1.17.0"
     ),
     esModule,
     scalaJSUseMainModuleInitializer := true

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,20 +1,20 @@
 {
-  "name": "b10",
-  "version": "0.0.0",
+  "name": "demo-flyio-jvm",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "b10",
-      "version": "0.0.0",
+      "name": "demo-flyio-jvm",
+      "version": "1.0.0",
       "dependencies": {
-        "@ui5/webcomponents": "1.8.0",
-        "@ui5/webcomponents-fiori": "1.8.0",
-        "@ui5/webcomponents-icons": "1.8.0"
+        "@ui5/webcomponents": "1.17.0",
+        "@ui5/webcomponents-fiori": "1.17.0",
+        "@ui5/webcomponents-icons": "1.17.0"
       },
       "devDependencies": {
         "http-proxy": "1.18.1",
-        "vite": "3.2.4",
+        "vite": "3.2.7",
         "vite-plugin-html": "3.2.0"
       }
     },
@@ -157,75 +157,103 @@
       }
     },
     "node_modules/@sap-theming/theming-base-content": {
-      "version": "11.1.41",
-      "resolved": "https://registry.npmjs.org/@sap-theming/theming-base-content/-/theming-base-content-11.1.41.tgz",
-      "integrity": "sha512-ffxq4uP7I/CowpXvXQxjNSBXEvMlZycoIZZyIbEoJmORYk+eUwMFTVf7DPriMDdsY/kSIEqse2xoPvHqdluPkg=="
+      "version": "11.6.4",
+      "resolved": "https://registry.npmjs.org/@sap-theming/theming-base-content/-/theming-base-content-11.6.4.tgz",
+      "integrity": "sha512-ub3W9qRO4Kt1nrXJBvTqUbQjpAhcQNGcIh1CTopVStpGGhEP1a2VPeXxJQPL37FCzIFeN898OBiQgCgQNpVqYQ=="
+    },
+    "node_modules/@types/jquery": {
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.20.tgz",
+      "integrity": "sha512-UI+EGhgYD4LdSZ8gaiziFqXYIIB38VQSDsnAs8jL/div7FGrzrShx4HKCykVzk3tPfiIlusdNP9Wi3G60LCF2Q==",
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
+    },
+    "node_modules/@types/openui5": {
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@types/openui5/-/openui5-1.118.0.tgz",
+      "integrity": "sha512-buNW71CfZwMrOnUG0gh7goK6dZMB1U06jJ+kdx4pkKjDCIqRDsnlxVoMu0GFHQIFz/sS52n6ljO3qxFXTSvGQQ==",
+      "dependencies": {
+        "@types/jquery": "*",
+        "@types/qunit": "*"
+      }
+    },
+    "node_modules/@types/qunit": {
+      "version": "2.19.6",
+      "resolved": "https://registry.npmjs.org/@types/qunit/-/qunit-2.19.6.tgz",
+      "integrity": "sha512-bz9STa6EHurtpSfn5cNiScBladlw43bM+7luQA985Kd9YlF4dZaLmKt3c5/oSyN1AWAl50YBpqTq0BxCP64nGg=="
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.4.tgz",
+      "integrity": "sha512-jA2llq2zNkg8HrALI7DtWzhALcVH0l7i89yhY3iBdOz6cBPeACoFq+fkQrjHA39t1hnSFOboZ7A/AY5MMZSlag=="
     },
     "node_modules/@types/trusted-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
-      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
+      "integrity": "sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ=="
     },
     "node_modules/@ui5/webcomponents": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ui5/webcomponents/-/webcomponents-1.8.0.tgz",
-      "integrity": "sha512-YcsWVTrOhwFuBuRDhlgT1xACK6r6BMkzzpSQwmmUD0RslILTRfB+/vqva+sHKI6Jre+xvrPcDZ7VR+XYLd4wRA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents/-/webcomponents-1.17.0.tgz",
+      "integrity": "sha512-uQxp8QiWcwMaSYwg5QD95QOkNcVXWwbqkyRfAWc2RHG51+cf3DN5ESrJtELeej6iw8LjkKKEdxRRC6bK7nVqMA==",
       "dependencies": {
-        "@ui5/webcomponents-base": "1.8.0",
-        "@ui5/webcomponents-icons": "1.8.0",
-        "@ui5/webcomponents-localization": "1.8.0",
-        "@ui5/webcomponents-theming": "1.8.0"
+        "@ui5/webcomponents-base": "1.17.0",
+        "@ui5/webcomponents-icons": "1.17.0",
+        "@ui5/webcomponents-localization": "1.17.0",
+        "@ui5/webcomponents-theming": "1.17.0"
       }
     },
     "node_modules/@ui5/webcomponents-base": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-base/-/webcomponents-base-1.8.0.tgz",
-      "integrity": "sha512-UUS+zm56pG1GP0D511FAucyrRWSGF7BVxWHSio9pLFQ+NpphuGoZAdim90aGxKyugYUv/Joicl6BE6pnvTo+kg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-base/-/webcomponents-base-1.17.0.tgz",
+      "integrity": "sha512-fy7NGNUvz028F7NVe6LNjkvlUOjLU4CwIE0AQHKt2V1F75iGuCzxDskXEawLQX6PhVScvvfJX6j2s1Rev6E9kQ==",
       "dependencies": {
         "lit-html": "^2.0.1"
       }
     },
     "node_modules/@ui5/webcomponents-fiori": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-fiori/-/webcomponents-fiori-1.8.0.tgz",
-      "integrity": "sha512-U6N6WxGz4TdteJb3kyhGqusFlvMRsiS25tzcbLv2Ry0QFwru88MJTSJ6IOQxcTtIeftWomBFjdl7OgdXlTe+Iw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-fiori/-/webcomponents-fiori-1.17.0.tgz",
+      "integrity": "sha512-fQFyKmYw5t1j1P0wDljPzVnoOdQsoj9T4bwETXi65L8w3nu+Er0d+DXx6hiWYY2lMuQ5XH6PVt0lqXpHN0RpUQ==",
       "dependencies": {
-        "@ui5/webcomponents": "1.8.0",
-        "@ui5/webcomponents-base": "1.8.0",
-        "@ui5/webcomponents-icons": "1.8.0",
-        "@ui5/webcomponents-theming": "1.8.0",
-        "@zxing/library": "^0.18.3"
+        "@ui5/webcomponents": "1.17.0",
+        "@ui5/webcomponents-base": "1.17.0",
+        "@ui5/webcomponents-icons": "1.17.0",
+        "@ui5/webcomponents-theming": "1.17.0",
+        "@zxing/library": "^0.17.1"
       }
     },
     "node_modules/@ui5/webcomponents-icons": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-icons/-/webcomponents-icons-1.8.0.tgz",
-      "integrity": "sha512-7DK1CUxWfVLgynhyclypgxUCGTEw38NPviHqB1/tHr4V6KeuCddSRsthfSyGoVU9aQkHD9RLRWD1C47yXeQM/A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-icons/-/webcomponents-icons-1.17.0.tgz",
+      "integrity": "sha512-Ie9jzO49xlSN/YONY8zKtZ4C1jyE92MxhFVFzr2FFxJSfvCnG/yCIHlbxKYMxgEW03FmWiEWRUDrzmz4ls0Egg==",
       "dependencies": {
-        "@ui5/webcomponents-base": "1.8.0"
+        "@ui5/webcomponents-base": "1.17.0"
       }
     },
     "node_modules/@ui5/webcomponents-localization": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-localization/-/webcomponents-localization-1.8.0.tgz",
-      "integrity": "sha512-8R/w9KLj83mD+yaPLqsMQtHORn+DaPHdLMWrbfB+CD+EoH6e+LHzGtKUA03ojLIJz9ZcJoMauYr624s/1uVkdQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-localization/-/webcomponents-localization-1.17.0.tgz",
+      "integrity": "sha512-TMe3Fxyp3VyxjPzArEtI2fMAkg8Pen6xKA+3A3v1aQJ+umpCIYp2xEA8O7jzApoFCR9L40MYsUuEmIybhOwifQ==",
       "dependencies": {
-        "@ui5/webcomponents-base": "1.8.0"
+        "@types/openui5": "^1.113.0",
+        "@ui5/webcomponents-base": "1.17.0"
       }
     },
     "node_modules/@ui5/webcomponents-theming": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-theming/-/webcomponents-theming-1.8.0.tgz",
-      "integrity": "sha512-DEPsDmcQ7AQk+57HoOc0Qbhcn/Y0cmFOCM8XRoD2nUQ05zvBNwdCxffevWgPF1G8+5AAw55cmsVrQs1fL7tXsw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-theming/-/webcomponents-theming-1.17.0.tgz",
+      "integrity": "sha512-dbsr6ff2y1091LABPaGjZh43fU8rhGDPExEGm5D1J7aOJIUOwWHO2vlxRanE4GElTxqla2ruiU7POAGosSnuVw==",
       "dependencies": {
-        "@sap-theming/theming-base-content": "11.1.41",
-        "@ui5/webcomponents-base": "1.8.0"
+        "@sap-theming/theming-base-content": "11.6.4",
+        "@ui5/webcomponents-base": "1.17.0"
       }
     },
     "node_modules/@zxing/library": {
-      "version": "0.18.6",
-      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.18.6.tgz",
-      "integrity": "sha512-bulZ9JHoLFd9W36pi+7e7DnEYNJhljYjZ1UTsKPOoLMU3qtC+REHITeCRNx40zTRJZx18W5TBRXt5pq2Uopjsw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.17.1.tgz",
+      "integrity": "sha512-RuiBZuteGaFXCle/b0X+g3peN8UpDc3pGe/J7hZBzKWaMZLbjensR7ja3vy47xWhXU4e8MICGqegPMxc2V2sow==",
       "dependencies": {
         "ts-custom-error": "^3.0.0"
       },
@@ -1188,9 +1216,9 @@
       }
     },
     "node_modules/lit-html": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.4.0.tgz",
-      "integrity": "sha512-G6qXu4JNUpY6aaF2VMfaszhO9hlWw0hOTRFDmuMheg/nDYGB+2RztUSOyrzALAbr8Nh0Y7qjhYkReh3rPnplVg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -1568,9 +1596,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.4.tgz",
-      "integrity": "sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.7.tgz",
+      "integrity": "sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.15.9",
@@ -1741,75 +1769,103 @@
       }
     },
     "@sap-theming/theming-base-content": {
-      "version": "11.1.41",
-      "resolved": "https://registry.npmjs.org/@sap-theming/theming-base-content/-/theming-base-content-11.1.41.tgz",
-      "integrity": "sha512-ffxq4uP7I/CowpXvXQxjNSBXEvMlZycoIZZyIbEoJmORYk+eUwMFTVf7DPriMDdsY/kSIEqse2xoPvHqdluPkg=="
+      "version": "11.6.4",
+      "resolved": "https://registry.npmjs.org/@sap-theming/theming-base-content/-/theming-base-content-11.6.4.tgz",
+      "integrity": "sha512-ub3W9qRO4Kt1nrXJBvTqUbQjpAhcQNGcIh1CTopVStpGGhEP1a2VPeXxJQPL37FCzIFeN898OBiQgCgQNpVqYQ=="
+    },
+    "@types/jquery": {
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.20.tgz",
+      "integrity": "sha512-UI+EGhgYD4LdSZ8gaiziFqXYIIB38VQSDsnAs8jL/div7FGrzrShx4HKCykVzk3tPfiIlusdNP9Wi3G60LCF2Q==",
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
+    "@types/openui5": {
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@types/openui5/-/openui5-1.118.0.tgz",
+      "integrity": "sha512-buNW71CfZwMrOnUG0gh7goK6dZMB1U06jJ+kdx4pkKjDCIqRDsnlxVoMu0GFHQIFz/sS52n6ljO3qxFXTSvGQQ==",
+      "requires": {
+        "@types/jquery": "*",
+        "@types/qunit": "*"
+      }
+    },
+    "@types/qunit": {
+      "version": "2.19.6",
+      "resolved": "https://registry.npmjs.org/@types/qunit/-/qunit-2.19.6.tgz",
+      "integrity": "sha512-bz9STa6EHurtpSfn5cNiScBladlw43bM+7luQA985Kd9YlF4dZaLmKt3c5/oSyN1AWAl50YBpqTq0BxCP64nGg=="
+    },
+    "@types/sizzle": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.4.tgz",
+      "integrity": "sha512-jA2llq2zNkg8HrALI7DtWzhALcVH0l7i89yhY3iBdOz6cBPeACoFq+fkQrjHA39t1hnSFOboZ7A/AY5MMZSlag=="
     },
     "@types/trusted-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
-      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
+      "integrity": "sha512-IDaobHimLQhjwsQ/NMwRVfa/yL7L/wriQPMhw1ZJall0KX6E1oxk29XMDeilW5qTIg5aoiqf5Udy8U/51aNoQQ=="
     },
     "@ui5/webcomponents": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ui5/webcomponents/-/webcomponents-1.8.0.tgz",
-      "integrity": "sha512-YcsWVTrOhwFuBuRDhlgT1xACK6r6BMkzzpSQwmmUD0RslILTRfB+/vqva+sHKI6Jre+xvrPcDZ7VR+XYLd4wRA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents/-/webcomponents-1.17.0.tgz",
+      "integrity": "sha512-uQxp8QiWcwMaSYwg5QD95QOkNcVXWwbqkyRfAWc2RHG51+cf3DN5ESrJtELeej6iw8LjkKKEdxRRC6bK7nVqMA==",
       "requires": {
-        "@ui5/webcomponents-base": "1.8.0",
-        "@ui5/webcomponents-icons": "1.8.0",
-        "@ui5/webcomponents-localization": "1.8.0",
-        "@ui5/webcomponents-theming": "1.8.0"
+        "@ui5/webcomponents-base": "1.17.0",
+        "@ui5/webcomponents-icons": "1.17.0",
+        "@ui5/webcomponents-localization": "1.17.0",
+        "@ui5/webcomponents-theming": "1.17.0"
       }
     },
     "@ui5/webcomponents-base": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-base/-/webcomponents-base-1.8.0.tgz",
-      "integrity": "sha512-UUS+zm56pG1GP0D511FAucyrRWSGF7BVxWHSio9pLFQ+NpphuGoZAdim90aGxKyugYUv/Joicl6BE6pnvTo+kg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-base/-/webcomponents-base-1.17.0.tgz",
+      "integrity": "sha512-fy7NGNUvz028F7NVe6LNjkvlUOjLU4CwIE0AQHKt2V1F75iGuCzxDskXEawLQX6PhVScvvfJX6j2s1Rev6E9kQ==",
       "requires": {
         "lit-html": "^2.0.1"
       }
     },
     "@ui5/webcomponents-fiori": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-fiori/-/webcomponents-fiori-1.8.0.tgz",
-      "integrity": "sha512-U6N6WxGz4TdteJb3kyhGqusFlvMRsiS25tzcbLv2Ry0QFwru88MJTSJ6IOQxcTtIeftWomBFjdl7OgdXlTe+Iw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-fiori/-/webcomponents-fiori-1.17.0.tgz",
+      "integrity": "sha512-fQFyKmYw5t1j1P0wDljPzVnoOdQsoj9T4bwETXi65L8w3nu+Er0d+DXx6hiWYY2lMuQ5XH6PVt0lqXpHN0RpUQ==",
       "requires": {
-        "@ui5/webcomponents": "1.8.0",
-        "@ui5/webcomponents-base": "1.8.0",
-        "@ui5/webcomponents-icons": "1.8.0",
-        "@ui5/webcomponents-theming": "1.8.0",
-        "@zxing/library": "^0.18.3"
+        "@ui5/webcomponents": "1.17.0",
+        "@ui5/webcomponents-base": "1.17.0",
+        "@ui5/webcomponents-icons": "1.17.0",
+        "@ui5/webcomponents-theming": "1.17.0",
+        "@zxing/library": "^0.17.1"
       }
     },
     "@ui5/webcomponents-icons": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-icons/-/webcomponents-icons-1.8.0.tgz",
-      "integrity": "sha512-7DK1CUxWfVLgynhyclypgxUCGTEw38NPviHqB1/tHr4V6KeuCddSRsthfSyGoVU9aQkHD9RLRWD1C47yXeQM/A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-icons/-/webcomponents-icons-1.17.0.tgz",
+      "integrity": "sha512-Ie9jzO49xlSN/YONY8zKtZ4C1jyE92MxhFVFzr2FFxJSfvCnG/yCIHlbxKYMxgEW03FmWiEWRUDrzmz4ls0Egg==",
       "requires": {
-        "@ui5/webcomponents-base": "1.8.0"
+        "@ui5/webcomponents-base": "1.17.0"
       }
     },
     "@ui5/webcomponents-localization": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-localization/-/webcomponents-localization-1.8.0.tgz",
-      "integrity": "sha512-8R/w9KLj83mD+yaPLqsMQtHORn+DaPHdLMWrbfB+CD+EoH6e+LHzGtKUA03ojLIJz9ZcJoMauYr624s/1uVkdQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-localization/-/webcomponents-localization-1.17.0.tgz",
+      "integrity": "sha512-TMe3Fxyp3VyxjPzArEtI2fMAkg8Pen6xKA+3A3v1aQJ+umpCIYp2xEA8O7jzApoFCR9L40MYsUuEmIybhOwifQ==",
       "requires": {
-        "@ui5/webcomponents-base": "1.8.0"
+        "@types/openui5": "^1.113.0",
+        "@ui5/webcomponents-base": "1.17.0"
       }
     },
     "@ui5/webcomponents-theming": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-theming/-/webcomponents-theming-1.8.0.tgz",
-      "integrity": "sha512-DEPsDmcQ7AQk+57HoOc0Qbhcn/Y0cmFOCM8XRoD2nUQ05zvBNwdCxffevWgPF1G8+5AAw55cmsVrQs1fL7tXsw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-theming/-/webcomponents-theming-1.17.0.tgz",
+      "integrity": "sha512-dbsr6ff2y1091LABPaGjZh43fU8rhGDPExEGm5D1J7aOJIUOwWHO2vlxRanE4GElTxqla2ruiU7POAGosSnuVw==",
       "requires": {
-        "@sap-theming/theming-base-content": "11.1.41",
-        "@ui5/webcomponents-base": "1.8.0"
+        "@sap-theming/theming-base-content": "11.6.4",
+        "@ui5/webcomponents-base": "1.17.0"
       }
     },
     "@zxing/library": {
-      "version": "0.18.6",
-      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.18.6.tgz",
-      "integrity": "sha512-bulZ9JHoLFd9W36pi+7e7DnEYNJhljYjZ1UTsKPOoLMU3qtC+REHITeCRNx40zTRJZx18W5TBRXt5pq2Uopjsw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.17.1.tgz",
+      "integrity": "sha512-RuiBZuteGaFXCle/b0X+g3peN8UpDc3pGe/J7hZBzKWaMZLbjensR7ja3vy47xWhXU4e8MICGqegPMxc2V2sow==",
       "requires": {
         "@zxing/text-encoding": "~0.9.0",
         "ts-custom-error": "^3.0.0"
@@ -2433,9 +2489,9 @@
       }
     },
     "lit-html": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.4.0.tgz",
-      "integrity": "sha512-G6qXu4JNUpY6aaF2VMfaszhO9hlWw0hOTRFDmuMheg/nDYGB+2RztUSOyrzALAbr8Nh0Y7qjhYkReh3rPnplVg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -2701,9 +2757,9 @@
       "dev": true
     },
     "vite": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.4.tgz",
-      "integrity": "sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.7.tgz",
+      "integrity": "sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==",
       "dev": true,
       "requires": {
         "esbuild": "^0.15.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,13 +7,13 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "3.2.4",
+    "vite": "3.2.7",
     "vite-plugin-html": "3.2.0",
     "http-proxy": "1.18.1"
   },
   "dependencies": {
-    "@ui5/webcomponents": "1.8.0",
-    "@ui5/webcomponents-fiori": "1.8.0",
-    "@ui5/webcomponents-icons": "1.8.0"
+    "@ui5/webcomponents": "1.17.0",
+    "@ui5/webcomponents-fiori": "1.17.0",
+    "@ui5/webcomponents-icons": "1.17.0"
   }
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
             port: 3000,
             proxy: {
                 "/api": {
-                    target: "http://localhost:9000"
+                    target: "http://127.0.0.1:9000"
                 }
             }
         },

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,7 +3,7 @@ import { createHtmlPlugin } from 'vite-plugin-html'
 
 import { defineConfig } from 'vite'
 
-const scalaVersion = "3.2.0"
+const scalaVersion = "3.3.1"
 
 export default defineConfig(({ command, mode, ssrBuild }) => {
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.0
+sbt.version = 1.9.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.12.0")
-addSbtPlugin("io.spray"           % "sbt-revolver"             % "0.9.1")
-addSbtPlugin("ch.epfl.scala"      % "sbt-bloop"                % "1.5.4")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.14.0")
+addSbtPlugin("io.spray"           % "sbt-revolver"             % "0.10.0")
+addSbtPlugin("ch.epfl.scala"      % "sbt-bloop"                % "1.5.11")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("com.eed3si9n"       % "sbt-assembly"             % "0.15.0")

--- a/server/src/main/scala/server/Server.scala
+++ b/server/src/main/scala/server/Server.scala
@@ -25,6 +25,9 @@ object Server extends cask.MainRoutes {
   @cask.get("/api")
   def hello() = "Hello World!"
 
+  @cask.get("/api/ping")
+  def ping() = "PONG"
+
   @cask.post("/api/do-thing")
   def doThing(request: cask.Request) =
     decode[SomeSharedData](request.text()) match {

--- a/server/src/main/scala/server/Server.scala
+++ b/server/src/main/scala/server/Server.scala
@@ -12,7 +12,7 @@ object Server extends cask.MainRoutes {
 
   override def host: String = Option(System.getProperty("isProd"))
     .map(_.toBoolean)
-    .fold("localhost")(isProd => if isProd then "0.0.0.0" else "localhost")
+    .fold("127.0.0.1")(isProd => if isProd then "0.0.0.0" else "127.0.0.1")
 
   @cask.get("/")
   def index() =


### PR DESCRIPTION
Nice setup, thanks!

The node.js fix simply makes sure that both cask and vite use IPv4, because their defaults became divergent in newer node versions, breaking vite proxying. This can be reproduced by running the current master with e.g. node.js 18 lts, and having this in /etc/hosts:

```
127.0.0.1  localhost
::1            localhost
```

The fix works for both node.js 16, and later versions.